### PR TITLE
Fix window icon on linux for child windows

### DIFF
--- a/mcvqoe/hub/shared.py
+++ b/mcvqoe/hub/shared.py
@@ -40,7 +40,7 @@ def add_mcv_icon(win):
                     win.iconbitmap(icon)
                 else:
                     logo = tk.PhotoImage(file=icon)
-                    win.call('wm', 'iconphoto', win._w, logo)
+                    win.iconphoto(True, logo)
             except TclError as e:
                 print(f'failed to add icon : {icon}, {e}')
         else:


### PR DESCRIPTION
The previous fix worked for the main window, but was giving an `AttributeError: 'CharDevDly' object has no attribute 'call'` when opening child windows. This fixes that.